### PR TITLE
Improve ubuntu build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It is recommended to install KDE Plasma along side this as Q::Shell utilizes man
 For Ubuntu/Debian-based systems, this command should be sufficient:
 
 ```
-sudo apt install extra-cmake-modules qtbase5-dev libx11-dev libkf5crash-dev libkf5kio-dev libkf5solid-dev libkf5jobwidgets-dev libkf5textwidgets-dev libkf5bookmarks-dev libkf5xmlgui-dev libkf5itemviews-dev libkf5attica-dev libkf5sonnet-dev libkf5globalaccel-dev libkf5guiaddons-dev libkf5codecs-dev libkf5auth-dev libkf5dbusaddons-dev libkf5coreaddons-dev libkf5iconthemes-dev libkf5configwidgets-dev libkf5widgetsaddons-dev libkf5service-dev libkf5config-dev libkf5windowsystem-dev libqt5concurrent5 libpulse-dev
+sudo apt install extra-cmake-modules qtbase5-dev libx11-dev libkf5crash-dev libkf5kio-dev libkf5solid-dev libkf5jobwidgets-dev libkf5textwidgets-dev libkf5bookmarks-dev libkf5xmlgui-dev libkf5itemviews-dev libkf5attica-dev libkf5sonnet-dev libkf5globalaccel-dev libkf5guiaddons-dev libkf5codecs-dev libkf5auth-dev libkf5dbusaddons-dev libkf5coreaddons-dev libkf5iconthemes-dev libkf5configwidgets-dev libkf5widgetsaddons-dev libkf5service-dev libkf5config-dev libkf5windowsystem-dev libqt5concurrent5 libpulse-dev libqt5x11extras5 libqt5x11extras5-dev
 ```
 
 You'll also need `dex` installed if you want to open applications in the dash.


### PR DESCRIPTION
on kubuntu 18.04, only libqt5x11extras5 was installed but libqt5x11extras5-dev was needed in order to compile successfully